### PR TITLE
Fix title array with empty string

### DIFF
--- a/frontend/site/.vitepress/theme/composables/dataProxy.js
+++ b/frontend/site/.vitepress/theme/composables/dataProxy.js
@@ -63,7 +63,10 @@ export default function useDataProxy(mapping, statuses) {
         const type = property.type;
         if (property.hasOwnProperty(type)) {
             if(type === "title") {
-                return property[type][0].plain_text;
+                /** @type {Array<{plain_text: string}>} */
+                const nonEmptyTitles = property[type].filter(title => title.plain_text).map(title => title.plain_text);
+                const titleOrEmpty = nonEmptyTitles.pop() || "";
+                return titleOrEmpty;
             }
             return getPropertyValue(property[type]);
         } else if(property.hasOwnProperty("name")) {


### PR DESCRIPTION
For some reason, Notion API returns title as Array even for page title.
We treated it as array with a single title inside but it can contain multiple values with empty strings and the real title.
Now, we filter the title array before taking the value.