### PR TITLE
Add new "Disponible sur data.gouv.fr" status

### DIFF
--- a/frontend/site/.vitepress/theme/components/InventoryBase.vue
+++ b/frontend/site/.vitepress/theme/components/InventoryBase.vue
@@ -71,7 +71,7 @@ const mapping = [
     key: "STATUT D'OUVERTURE",
     label: "Statut",
     format: (cell, row) =>
-      `<span class="fr-badge fr-badge--no-icon ${row.status?._class}">${cell}</a>`,
+      `<span class="fr-badge fr-badge--no-icon ${row.status?._class ?? ""}">${cell}</a>`,
     width: "12em",
   },
   {
@@ -104,10 +104,15 @@ const mappingWithLabels = mapping.filter(column => column.label);
  * @type {Array<import("../types").Status>}
  */
 const statuses = [
+{
+    label: "Disponible sur data.gouv.fr",
+    key: "open-on-site",
+    _class: "fr-badge--success",
+  },
   {
     label: "Disponible",
     key: "open",
-    _class: "fr-badge--success",
+    _class: "fr-badge--info",
   },
   {
     label: "Planifié",

--- a/frontend/site/.vitepress/theme/types.js
+++ b/frontend/site/.vitepress/theme/types.js
@@ -2,7 +2,7 @@
 /** @typedef {{label?: string, format?: (cell: object | string, row: Row) => string, transform?: (cell: Array | Object) => string, width?: string}} ColumnConfiguration */
 /** @typedef {{key: string} & ColumnConfiguration} Column */
 /** 
- * @typedef {"todefine" | "opening" | "open" | "notopen" } StatusKey
+ * @typedef {"todefine" | "opening" | "open" | "open-on-site" | "notopen" } StatusKey
  * @typedef {{label: string, key: StatusKey, _class: string}} Status
 */
 /** @typedef {{id: string, TYPE: string, CATEGORIE: string, TITLE: string, LIEN: string, PRODUCTEUR: string, status: Status, "DATE ESTIMÉE": string | null, "MINISTÈRE DE TUTELLE": string}} Row */


### PR DESCRIPTION
This PR adds a new status to the array.

It also fixes an `undefined` written as class when the label isn't know.

Closes https://github.com/etalab/data.gouv.fr/issues/1280